### PR TITLE
Revise Codepointer docs a bit

### DIFF
--- a/docs/developer_spec.md
+++ b/docs/developer_spec.md
@@ -217,6 +217,7 @@ MBF21 defaults:
   - `uint`: An unsigned integer. Must be greater than or equal to zero.
   - `fixed` A [fixed-point](https://doomwiki.org/wiki/Fixed_point) number.
     - For user-friendliness, a suggested convention for MBF21-supporting DEHACKED tools is to convert numbers with decimal points to their fixed-point representation when saving the patch (e.g. "1.0" gets saved as "65536"), so this doesn't get super-ugly on the user side of life.
+  - The reference implementation of these codepointers in dsda-doom is designed to be as easy to implement as possible for Boom-derived sourceports. Though some modification of internal functions is needed for certain codepointers, the changes are minimally invasive and should not require mounds of refactoring.
 
 ##### Actor pointers
 
@@ -245,37 +246,37 @@ MBF21 defaults:
     - `hoffset (fixed)`: Horizontal spawn offset, relative to calling actor's angle
     - `voffset (fixed)`: Vertical spawn offset, relative to actor's default projectile fire height
   - Notes:
-    - The `pitch` arg uses the same approximated pitch calculation that Doom's monster aim / autoaim uses. Refer to the implementation for specifics.
     - The spawned projectile's `tracer` pointer is always set to the spawner's `target`, for generic seeker missile support.
+    - For demo-compatible ports, the `pitch` arg must use the same approximated slope calculation that Doom's monster aim / autoaim uses (finetangent table) & only adjust the projectile's z-velocity, rather than calculate true 3D pitch.
 
 - **A_MonsterBulletAttack(hspread, vspread, numbullets, damagebase, damagedice)**
   - Generic monster bullet attack.
   - Args:
     - `hspread (fixed)`: Horizontal spread (degrees, in fixed point)
     - `vspread (fixed)`: Vertical spread (degrees, in fixed point)
-    - `numbullets (int)`: Number of bullets to fire; if not set, defaults to 1
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 5
+    - `numbullets (uint)`: Number of bullets to fire; if not set, defaults to 1
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 3
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 5
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
-    - Damage arg defaults are identical to Doom's usual monster bullet attack values.
-    - Entering a negative value for `numbullets`, `damagebase`, and `damagedice` is undefined behavior (for now).
+    - Damage arg defaults are identical to Doom's monster bullet attack damage values.
+    - For demo-compatible ports, the `vspread` arg must use the same approximated slope calculation that Doom's monster aim / autoaim uses (finetangent table), rather than calculate true 3D pitch.
 
 - **A_MonsterMeleeAttack(damagebase, damagedice, sound, range)**
   - Generic monster melee attack.
   - Args:
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 8
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 3
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 8
     - `sound (uint)`: Sound to play if attack hits
     - `range (fixed)`: Attack range; if not set, defaults to calling actor's melee range property
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
 
 - **A_RadiusDamage(damage, radius)**
-  - Generic A_Explode (hell yeah).
+  - Generic explosion.
   - Args:
-    - `damage (int)`: Max explosion damge
-    - `radius (int)`: Explosion radius
+    - `damage (uint)`: Max explosion damge
+    - `radius (uint)`: Explosion radius, in map units
 
 - **A_NoiseAlert**
   - Alerts monsters within sound-travel distance of the calling actor's target.
@@ -294,25 +295,25 @@ MBF21 defaults:
     - `maxturnangle (fixed)`: Maximum angle a missile will turn towards the target if angle is above the threshold
   - Notes:
     - When using this function, keep in mind that seek 'strength' also depends on how often this function is called -- e.g. calling `A_SeekTracer` every tic will result in a much more aggressive seek than calling it every 4 tics, even if the args are the same
-    - This function uses Heretic's seeker missile logic (P_SeekerMissile), rather than Doom's, with two notable changes:
+    - This function uses Heretic's seeker missile logic (P_SeekerMissile), rather than Doom's, with the following changes:
       - The actor's `tracer` pointer is used as the seek target, rather than Heretic's `special1` field
-      - On the z-axis, the missile will seek towards the vertical centerpoint of the seek target, rather than the bottom (resulting in much friendly behavior when seeking toward enemies on high ledges). Refer to the implementation for details.
+      - On the z-axis, the missile will seek towards the vertical centerpoint of the seek target, rather than the bottom (resulting in much friendly behavior when seeking toward enemies on high ledges).
+      - Z-axis seeking will always be attempted, rather than use Heretic's behavior of skipping the Z-axis adjustment if the missile's z position falls between the actor's top/bottom z positions.
 
-- **A_FindTracer(fov, distance)**
+- **A_FindTracer(fov, rangeblocks)**
   - Searches for a valid tracer (seek target), if the calling actor doesn't already have one. Particularly useful for player missiles.
   - Args:
     - `fov (fixed)`: Field-of-view, relative to calling actor's angle, to search for targets in. If zero, the search will occur in all directions.
-    - `distance (int)`: Distance to search, in map blocks (128 units); if not set, defaults to 10. Setting this value too high may hurt performance, so don't get overzealous.
+    - `rangeblocks (uint)`: Distance to search, in map blocks (128 units); if not set, defaults to 10. 
   - Notes:
-    - This function is intended for use on player-fired missiles; it may not produce particularly useful results if used on a monster projectile.
     - This function will no-op if the calling actor already has a tracer. To forcibly re-acquire a new tracer, call A_ClearTracer first.
-    - This function uses a variant of Hexen's blockmap search algorithm (P_RoughMonsterSearch); refer to the implementation for specifics, but it's identical to Hexen's except for the rules for picking a valid target (in order of evaluation):
+    - This function uses a variant of Hexen's blockmap search algorithm (P_RoughMonsterSearch), with the rules for picking a valid target defined as follows (in order of evaluation):
       - Actors without the SHOOTABLE flag are skipped
       - The projectile's owner (target) is skipped
       - Actors on the same "team" are skipped (e.g. MF_FRIEND actors will not pick players or fellow MF_FRIENDs), with a few exceptions:
         - If actors are infighting (i.e. candidate actor is projectile owner's target), actor will not be skipped
         - Players will not be skipped in deathmatch
-          - This rule is to work around a weird quirk in MBF (namely, that players have MF_FRIEND set even in DM); ports with a robust "team" implementation may be able to do a smarter check here in general.
+          - This rule is to work around a weird quirk in MBF (namely, that players have MF_FRIEND set even in DM); ports with a robust "team" implementation may wish to adjust or append to this logic to take player team into account.
       - If the `fov` arg is nonzero, actors outside of an `fov`-degree cone, relative to the missile's angle, are skipped
       - Actors not in line-of-sight of the missile are skipped
 
@@ -338,10 +339,10 @@ MBF21 defaults:
   - Jumps to a state if caller's target is closer than the specified distance.
   - Args:
     - `state (uint)`: State to jump to
-    - `distance (int)`: Distance threshold, in map units
+    - `distance (fixed)`: Distance threshold, in map units
   - Notes:
-    - This function uses the same approximate distance check as other functions in the game (P_AproxDistance).
-    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTargetCloser(420, 69)` will jump to state 420 if distance is 68 or lower.
+    - For demo-compatible ports, this function must the same approximate distance check as other functions in the game (P_AproxDistance).
+    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTargetCloser(420, 69.0)` will jump to state 420 if distance is 68.0 or lower.
 
 - **A_JumpIfTracerInSight(state)**
   - Jumps to a state if caller's tracer (seek target) is in line-of-sight.
@@ -355,8 +356,8 @@ MBF21 defaults:
     - `state (uint)`: State to jump to
     - `distance (fixed)`: Distance threshold, in map units
   - Notes:
-    - This function uses the same approximate distance check as other functions in the game (P_AproxDistance).
-    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTracerCloser(420, 69)` will jump to state 420 if distance is 68 or lower.
+    - For demo-compatible ports, this function must the same approximate distance check as other functions in the game (P_AproxDistance).
+    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTracerCloser(420, 69.0)` will jump to state 420 if distance is 68.0 or lower.
 
 - **A_JumpIfFlagsSet(state, flags, flags2)**
   - Jumps to a state if caller has the specified thing flags set.
@@ -391,30 +392,31 @@ MBF21 defaults:
     - `voffset (fixed)`: Vertical spawn offset, relative to player's default projectile fire height
   - Notes:
     - Unlike native Doom attack codepointers, this function will not consume ammo, trigger the Flash state, or play a sound.
-    - The `pitch` arg uses the same approximated pitch calculation that Doom's monster aim / autoaim uses. Refer to the implementation for specifics.
     - The spawned projectile's `tracer` pointer is set to the player's autoaim target, if available.
+    - For demo-compatible ports, the `pitch` arg must use the same approximated slope calculation that Doom's monster aim / autoaim uses (finetangent table) & only adjust the projectile's z-velocity, rather than calculate true 3D pitch.
 
 - **A_WeaponBulletAttack(hspread, vspread, numbullets, damagebase, damagedice)**
   - Generic weapon bullet attack.
   - Args:
     - `hspread (fixed)`: Horizontal spread (degrees, in fixed point)
     - `vspread (fixed)`: Vertical spread (degrees, in fixed point)
-    - `numbullets (int)`: Number of bullets to fire; if not set, defaults to 1
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 5
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 3
+    - `numbullets (uint)`: Number of bullets to fire; if not set, defaults to 1
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 5
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 3
   - Notes:
     - Unlike native Doom attack codepointers, this function will not consume ammo, trigger the Flash state, or play a sound.
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
-    - Damage arg defaults are identical to Doom's usual monster bullet attack values.
-      - Note that these defaults are different for weapons and monsters (5d3 vs 3d5) -- yup, Doom did it this way. :P
+    - Damage arg defaults are identical to Doom's weapon bullet attack damage values.
+      - Note that these defaults are intentionally different for weapons vs monsters (5d3 vs 3d5) -- yup, Doom did it this way. :P
+    - For demo-compatible ports, the `vspread` arg must use the same approximated slope calculation that Doom's monster aim / autoaim uses (finetangent table), rather than calculate true 3D pitch.
 
 - **A_WeaponMeleeAttack(damagebase, damagedice, zerkfactor, sound, range)**
   - Generic weapon melee attack.
   - Args:
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 2
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 10
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 2
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 10
     - `zerkfactor (fixed)`: Berserk damage multiplier; if not set, defaults to 1.0
-    - `sound (uint)`: Sound to play if attack hits
+    - `sound (uint)`: Sound index to play if attack hits
     - `range (fixed)`: Attack range; if not set, defaults to player mobj's melee range property
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`; this is then multiplied by `zerkfactor` if the player has Berserk.
@@ -422,14 +424,14 @@ MBF21 defaults:
 - **A_WeaponSound(sound, fullvol)**
   - Generic playsound for weapons.
   - Args:
-    - `sound (uint)`: DEH Index of sound to play.
+    - `sound (uint)`: Sound index to play.
     - `fullvol (int)`: If nonzero, play this sound at full volume across the entire map.
 
 - **A_WeaponJump(state, chance)**
   - Random state jump for weapons.
   - Args:
     - `state (uint)`: State index to jump to.
-    - `chance (int)`: Chance out of 256 to perform the jump. 0 never jumps, 256 always jumps.
+    - `chance (int)`: Chance out of 256 to perform the jump. 0 (or below) never jumps, 256 (or higher) always jumps.
 
 - **A_ConsumeAmmo(amount)**
   - Subtracts ammo from the currently-selected weapon's ammo pool.
@@ -438,14 +440,15 @@ MBF21 defaults:
   - Notes:
     - This function will not reduce ammo below zero.
     - This function will no-op if the current weapon uses the `am_noammo` ("None"/"Infinite") ammotype.
+    - If `amount` is negative, ammo will be added to the ammo pool instead.
 
 - **A_CheckAmmo(state, amount)**
   - Jumps to `state` if ammo is below `amount`.
   - Args:
     - `state (uint)`: State index to jump to.
-    - `amount (int)`: Amount of ammo to check. If zero, will default to the current weapon's `ammopershot` value.
+    - `amount (uint)`: Amount of ammo to check. If zero, will default to the current weapon's `ammopershot` value.
   - Notes:
-    - The jump will only occur if ammo is BELOW the given value -- e.g. `A_CheckAmmo(420, 695)` will jump to state 420 if ammo is 68 or lower.
+    - The jump will only occur if ammo is BELOW the given value -- e.g. `A_CheckAmmo(420, 69)` will jump to state 420 if ammo is 68 or lower.
     - This function will no-op if the current weapon uses the `am_noammo` ("None"/"Infinite") ammotype.
 
 - **A_RefireTo(state, noammocheck)**
@@ -461,7 +464,7 @@ MBF21 defaults:
     - `nothirdperson (int)`: If nonzero, do not change the 3rd-person player sprite to the player muzzleflash state.
 
 - **A_WeaponAlert**
-  - Alerts monsters within sound-travel distance of the player's presence. Handy when combined with the WPF_SILENT flag.
+  - Alerts monsters within sound-travel distance of the player's presence. Useful for weapons with the WPF_SILENT flag set.
   - No Args.
 
 ## Miscellaneous

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -248,7 +248,6 @@ MBF21 defaults:
     - `hoffset (fixed)`: Horizontal spawn offset, relative to calling actor's angle
     - `voffset (fixed)`: Vertical spawn offset, relative to actor's default projectile fire height
   - Notes:
-    - The `pitch` arg uses the same approximated pitch calculation that Doom's monster aim / autoaim uses. Refer to the implementation for specifics.
     - The spawned projectile's `tracer` pointer is always set to the spawner's `target`, for generic seeker missile support.
 
 - **A_MonsterBulletAttack(hspread, vspread, numbullets, damagebase, damagedice)**
@@ -256,29 +255,28 @@ MBF21 defaults:
   - Args:
     - `hspread (fixed)`: Horizontal spread (degrees, in fixed point)
     - `vspread (fixed)`: Vertical spread (degrees, in fixed point)
-    - `numbullets (int)`: Number of bullets to fire; if not set, defaults to 1
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 5
+    - `numbullets (uint)`: Number of bullets to fire; if not set, defaults to 1
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 3
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 5
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
-    - Damage arg defaults are identical to Doom's usual monster bullet attack values.
-    - Entering a negative value for `numbullets`, `damagebase`, and `damagedice` is undefined behavior (for now).
+    - Damage arg defaults are identical to Doom's monster bullet attack damage values.
 
 - **A_MonsterMeleeAttack(damagebase, damagedice, sound, range)**
   - Generic monster melee attack.
   - Args:
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 3
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 8
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 3
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 8
     - `sound (uint)`: Sound to play if attack hits
     - `range (fixed)`: Attack range; if not set, defaults to calling actor's melee range property
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
 
 - **A_RadiusDamage(damage, radius)**
-  - Generic A_Explode (hell yeah).
+  - Generic explosion.
   - Args:
-    - `damage (int)`: Max explosion damge
-    - `radius (int)`: Explosion radius
+    - `damage (uint)`: Max explosion damge
+    - `radius (uint)`: Explosion radius, in map units
 
 - **A_NoiseAlert**
   - Alerts monsters within sound-travel distance of the calling actor's target.
@@ -297,27 +295,17 @@ MBF21 defaults:
     - `maxturnangle (fixed)`: Maximum angle a missile will turn towards the target if angle is above the threshold
   - Notes:
     - When using this function, keep in mind that seek 'strength' also depends on how often this function is called -- e.g. calling `A_SeekTracer` every tic will result in a much more aggressive seek than calling it every 4 tics, even if the args are the same
-    - This function uses Heretic's seeker missile logic (P_SeekerMissile), rather than Doom's, with two notable changes:
-      - The actor's `tracer` pointer is used as the seek target, rather than Heretic's `special1` field
-      - On the z-axis, the missile will seek towards the vertical centerpoint of the seek target, rather than the bottom (resulting in much friendly behavior when seeking toward enemies on high ledges). Refer to the implementation for details.
+    - This function is based on Heretic's seeker missile logic, rather than Doom's, so there are some slight differences in behavior compared to A_Tracer (better z-axis seeking, for instance).
 
-- **A_FindTracer(fov, distance)**
+- **A_FindTracer(fov, rangeblocks)**
   - Searches for a valid tracer (seek target), if the calling actor doesn't already have one. Particularly useful for player missiles.
   - Args:
     - `fov (fixed)`: Field-of-view, relative to calling actor's angle, to search for targets in. If zero, the search will occur in all directions.
-    - `distance (int)`: Distance to search, in map blocks (128 units); if not set, defaults to 10. Setting this value too high may hurt performance, so don't get overzealous.
+    - `rangeblocks (uint)`: Distance to search, in map blocks (128 units); if not set, defaults to 10. 
   - Notes:
-    - This function is intended for use on player-fired missiles; it may not produce particularly useful results if used on a monster projectile.
+    - Setting the `rangeblocks` arg too high may hurt performance, so don't get overzealous.
     - This function will no-op if the calling actor already has a tracer. To forcibly re-acquire a new tracer, call A_ClearTracer first.
-    - This function uses a variant of Hexen's blockmap search algorithm (P_RoughMonsterSearch); refer to the implementation for specifics, but it's identical to Hexen's except for the rules for picking a valid target (in order of evaluation):
-      - Actors without the SHOOTABLE flag are skipped
-      - The projectile's owner (target) is skipped
-      - Actors on the same "team" are skipped (e.g. MF_FRIEND actors will not pick players or fellow MF_FRIENDs), with a few exceptions:
-        - If actors are infighting (i.e. candidate actor is projectile owner's target), actor will not be skipped
-        - Players will not be skipped in deathmatch
-          - This rule is to work around a weird quirk in MBF (namely, that players have MF_FRIEND set even in DM); ports with a robust "team" implementation may be able to do a smarter check here in general.
-      - If the `fov` arg is nonzero, actors outside of an `fov`-degree cone, relative to the missile's angle, are skipped
-      - Actors not in line-of-sight of the missile are skipped
+    - This function will exclude any actor that is "friendly" to the shooter (e.g. players will not target friendly monsters, enemy monsters will not target each other unless infighting, and so forth).
 
 - **A_ClearTracer**
   - Clears the calling actor's tracer (seek target) field.
@@ -341,10 +329,9 @@ MBF21 defaults:
   - Jumps to a state if caller's target is closer than the specified distance.
   - Args:
     - `state (uint)`: State to jump to
-    - `distance (int)`: Distance threshold, in map units
+    - `distance (fixed)`: Distance threshold, in map units
   - Notes:
-    - This function uses the same approximate distance check as other functions in the game (P_AproxDistance).
-    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTargetCloser(420, 69)` will jump to state 420 if distance is 68 or lower.
+    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTargetCloser(420, 69.0)` will jump to state 420 if distance is 68.0 or lower.
 
 - **A_JumpIfTracerInSight(state)**
   - Jumps to a state if caller's tracer (seek target) is in line-of-sight.
@@ -358,8 +345,7 @@ MBF21 defaults:
     - `state (uint)`: State to jump to
     - `distance (fixed)`: Distance threshold, in map units
   - Notes:
-    - This function uses the same approximate distance check as other functions in the game (P_AproxDistance).
-    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTracerCloser(420, 69)` will jump to state 420 if distance is 68 or lower.
+    - The jump will only occur if distance is BELOW the given value -- e.g. `A_JumpIfTracerCloser(420, 69.0)` will jump to state 420 if distance is 68.0 or lower.
 
 - **A_JumpIfFlagsSet(state, flags, flags2)**
   - Jumps to a state if caller has the specified thing flags set.
@@ -394,7 +380,6 @@ MBF21 defaults:
     - `voffset (fixed)`: Vertical spawn offset, relative to player's default projectile fire height
   - Notes:
     - Unlike native Doom attack codepointers, this function will not consume ammo, trigger the Flash state, or play a sound.
-    - The `pitch` arg uses the same approximated pitch calculation that Doom's monster aim / autoaim uses. Refer to the implementation for specifics.
     - The spawned projectile's `tracer` pointer is set to the player's autoaim target, if available.
 
 - **A_WeaponBulletAttack(hspread, vspread, numbullets, damagebase, damagedice)**
@@ -402,22 +387,22 @@ MBF21 defaults:
   - Args:
     - `hspread (fixed)`: Horizontal spread (degrees, in fixed point)
     - `vspread (fixed)`: Vertical spread (degrees, in fixed point)
-    - `numbullets (int)`: Number of bullets to fire; if not set, defaults to 1
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 5
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 3
+    - `numbullets (uint)`: Number of bullets to fire; if not set, defaults to 1
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 5
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 3
   - Notes:
     - Unlike native Doom attack codepointers, this function will not consume ammo, trigger the Flash state, or play a sound.
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`
-    - Damage arg defaults are identical to Doom's usual monster bullet attack values.
-      - Note that these defaults are different for weapons and monsters (5d3 vs 3d5) -- yup, Doom did it this way. :P
+    - Damage arg defaults are identical to Doom's weapon bullet attack damage values.
+      - Note that these defaults are intentionally different for weapons vs monsters (5d3 vs 3d5) -- yup, Doom did it this way. :P
 
 - **A_WeaponMeleeAttack(damagebase, damagedice, zerkfactor, sound, range)**
   - Generic weapon melee attack.
   - Args:
-    - `damagebase (int)`: Base damage of attack; if not set, defaults to 2
-    - `damagedice (int)`: Attack damage random multiplier; if not set, defaults to 10
+    - `damagebase (uint)`: Base damage of attack; if not set, defaults to 2
+    - `damagedice (uint)`: Attack damage random multiplier; if not set, defaults to 10
     - `zerkfactor (fixed)`: Berserk damage multiplier; if not set, defaults to 1.0
-    - `sound (uint)`: Sound to play if attack hits
+    - `sound (uint)`: Sound index to play if attack hits
     - `range (fixed)`: Attack range; if not set, defaults to player mobj's melee range property
   - Notes:
     - Damage formula is: `damage = (damagebase * random(1, damagedice))`; this is then multiplied by `zerkfactor` if the player has Berserk.
@@ -425,14 +410,14 @@ MBF21 defaults:
 - **A_WeaponSound(sound, fullvol)**
   - Generic playsound for weapons.
   - Args:
-    - `sound (uint)`: DEH Index of sound to play.
+    - `sound (uint)`: Sound index to play.
     - `fullvol (int)`: If nonzero, play this sound at full volume across the entire map.
 
 - **A_WeaponJump(state, chance)**
   - Random state jump for weapons.
   - Args:
     - `state (uint)`: State index to jump to.
-    - `chance (int)`: Chance out of 256 to perform the jump. 0 never jumps, 256 always jumps.
+    - `chance (int)`: Chance out of 256 to perform the jump. 0 (or below) never jumps, 256 (or higher) always jumps.
 
 - **A_ConsumeAmmo(amount)**
   - Subtracts ammo from the currently-selected weapon's ammo pool.
@@ -440,16 +425,15 @@ MBF21 defaults:
     - `amount (int)`: Amount of ammo to subtract. If zero, will default to the current weapon's `ammopershot` value.
   - Notes:
     - This function will not reduce ammo below zero.
-    - This function will no-op if the current weapon uses the `am_noammo` ("None"/"Infinite") ammotype.
+    - If `amount` is negative, ammo will be added to the ammo pool instead.
 
 - **A_CheckAmmo(state, amount)**
   - Jumps to `state` if ammo is below `amount`.
   - Args:
     - `state (uint)`: State index to jump to.
-    - `amount (int)`: Amount of ammo to check. If zero, will default to the current weapon's `ammopershot` value.
+    - `amount (uint)`: Amount of ammo to check. If zero, will default to the current weapon's `ammopershot` value.
   - Notes:
-    - The jump will only occur if ammo is BELOW the given value -- e.g. `A_CheckAmmo(420, 695)` will jump to state 420 if ammo is 68 or lower.
-    - This function will no-op if the current weapon uses the `am_noammo` ("None"/"Infinite") ammotype.
+    - The jump will only occur if ammo is BELOW the given value -- e.g. `A_CheckAmmo(420, 69)` will jump to state 420 if ammo is 68 or lower.
 
 - **A_RefireTo(state, noammocheck)**
   - Jumps to `state` if the fire button is currently being pressed and the weapon has enough ammo to fire.
@@ -464,7 +448,7 @@ MBF21 defaults:
     - `nothirdperson (int)`: If nonzero, do not change the 3rd-person player sprite to the player muzzleflash state.
 
 - **A_WeaponAlert**
-  - Alerts monsters within sound-travel distance of the player's presence. Handy when combined with the WPF_SILENT flag.
+  - Alerts monsters within sound-travel distance of the player's presence. Useful for weapons with the WPF_SILENT flag set.
   - No Args.
 
 ## Miscellaneous


### PR DESCRIPTION
Just did a pass through the codepointers section, editing wording, adding some clarifications, and fixing some stuff -- lots of args were "int" instead of "uint" for instance D:

I also removed some of the geeky details from the base spec.md (e.g. "function uses Hexen's algorithm, blahblah"), just to reduce clutter a bit. Should make it a slightly more user-friendly reference. Fingers crossed. :P