### PR TITLE
Update to v1.5, add `comp_thingsectorlight`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The specification is available in different formats to suit different audiences:
 
 ### Version History
 - v1.5
-  - Added comp_thingsectorlight option (Boom-transferred sector light level behaves more preditably)
+  - Added comp_thingsectorlight option (Boom-transferred sector light level behaves more predictably)
 - v1.4
   - Added comp_reservedlineflag option (ignore extended flags when set).
 - v1.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Modder's Best Friend aka MBF21 v1.4
+# Modder's Best Friend aka MBF21 v1.5
 MBF21 is the next step in the classical / conservative feature progression from doom to boom to mbf. The project has these goals:
 
 - Fix bugs and miscellaneous issues in mbf.
@@ -18,6 +18,8 @@ The specification is available in different formats to suit different audiences:
 - OPTIONS lump [examples](./docs/options.md).
 
 ### Version History
+- v1.5
+  - Added comp_thingsectorlight option (Boom-transferred sector light level behaves more preditably)
 - v1.4
   - Added comp_reservedlineflag option (ignore extended flags when set).
 - v1.3

--- a/docs/developer_spec.md
+++ b/docs/developer_spec.md
@@ -581,7 +581,7 @@ Summary of comp flags since mbf in pr+ and changes:
 - The comp list size is variable - take care when reading demos.
   - If the comp list size is <24, then comp_voodooscroller equals 1.
   - If the comp list size is <25, then comp_reservedlineflag equals 0.
-  - If the comp list size is <26, then comp_reservedlineflag equals 0.
+  - If the comp list size is <26, then comp_thingsectorlight equals 0.
 
 #### Fixes / adjustments since mbf
 - Fix 3 key door bug

--- a/docs/developer_spec.md
+++ b/docs/developer_spec.md
@@ -487,6 +487,9 @@ MBF21 defaults:
 - comp_reservedlineflag: [commit](https://github.com/kraflab/dsda-doom/commit/5287a80982ce290a035a8fe0aa3e35582ca119cb), [commit](https://github.com/kraflab/dsda-doom/commit/ee84aef86f3d9005d30f330666e3c172f785c819)
   - When on: the line flag 0x0800 clears extended flags (`flags &= 0x01ff`).
   - When off: the line flag 0x0800 means nothing.
+- comp_thingsectorlight: [PR](https://github.com/kraflab/dsda-doom/pull/820)
+  - When on: sprites that are on sectors using Boom's floor/ceiling transfered light levels will use the average of those two values.
+  - When on: sprties will always be drawn with the Mobj's sector's light level.
 
 Summary of comp flags since mbf in pr+ and changes:
 
@@ -505,6 +508,7 @@ Summary of comp flags since mbf in pr+ and changes:
 | comp_friendlyspawn    | 29    | 1       | A_Spawn new thing inherits friendliness        |
 | comp_voodooscroller   | 30    | 0       | Voodoo dolls on slow scrollers move too slowly |
 | comp_reservedlineflag | 31    | 1       | Line flag 0x0800 clears extended flags         |
+| comp_thingsectorlight | 32    | 0       | MObjs are lit according to the average of transferred light levels |
 
 - Comp options marked with a `-` have been deoptionalized in mbf21 (forced to `0`). Many of these have nothing to do with demo compatibility - others are simple bug fixes.
 - Comp options marked with a `*` are already implemented in EE.
@@ -572,10 +576,12 @@ Summary of comp flags since mbf in pr+ and changes:
 | comp_friendlyspawn    | 1     |
 | comp_voodooscroller   | 1     |
 | comp_reservedlineflag | 1     |
+| comp_thingsectorlight | 1     |
 
 - The comp list size is variable - take care when reading demos.
   - If the comp list size is <24, then comp_voodooscroller equals 1.
   - If the comp list size is <25, then comp_reservedlineflag equals 0.
+  - If the comp list size is <26, then comp_reservedlineflag equals 0.
 
 #### Fixes / adjustments since mbf
 - Fix 3 key door bug

--- a/docs/developer_spec.md
+++ b/docs/developer_spec.md
@@ -489,7 +489,7 @@ MBF21 defaults:
   - When off: the line flag 0x0800 means nothing.
 - comp_thingsectorlight: [PR](https://github.com/kraflab/dsda-doom/pull/820)
   - When on: sprites that are on sectors using Boom's floor/ceiling transfered light levels will use the average of those two values.
-  - When on: sprties will always be drawn with the Mobj's sector's light level.
+  - When off: sprites will always be drawn with the Mobj's sector's light level.
 
 Summary of comp flags since mbf in pr+ and changes:
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -40,7 +40,7 @@ The OPTIONS lump (originally from mbf) allows wad authors to set a series of var
 | comp_friendlyspawn    | Spawned things inherit the friend attribute from the source    |
 | comp_voodooscroller   | Voodoo dolls on slow scrollers move too slowly                 |
 | comp_reservedlineflag | The line flag 0x0800 disables extended flags                   |
-| comp_thingsectorlight | Things are lit up by the average of trasnfered light levels    |
+| comp_thingsectorlight | Sprites are lit up by the average of transferred light levels  |
 
 ### MBF21 Defaults
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -40,6 +40,7 @@ The OPTIONS lump (originally from mbf) allows wad authors to set a series of var
 | comp_friendlyspawn    | Spawned things inherit the friend attribute from the source    |
 | comp_voodooscroller   | Voodoo dolls on slow scrollers move too slowly                 |
 | comp_reservedlineflag | The line flag 0x0800 disables extended flags                   |
+| comp_thingsectorlight | Things are lit up by the average of trasnfered light levels    |
 
 ### MBF21 Defaults
 
@@ -83,6 +84,7 @@ comp_ledgeblock 1
 comp_friendlyspawn 1
 comp_voodooscroller 0
 comp_reservedlineflag 1
+comp_thingsectorlight 0
 ```
 
 ### MBF Defaults
@@ -126,6 +128,7 @@ comp_ledgeblock 0
 comp_friendlyspawn 1
 comp_voodooscroller 1
 comp_reservedlineflag 1
+comp_thingsectorlight 1
 ```
 
 ### Boom
@@ -169,6 +172,7 @@ comp_ledgeblock 0
 comp_friendlyspawn 1
 comp_voodooscroller 0
 comp_reservedlineflag 1
+comp_thingsectorlight 0
 ```
 
 ### Doom 2
@@ -212,6 +216,7 @@ comp_ledgeblock 1
 comp_friendlyspawn 1
 comp_voodooscroller 0
 comp_reservedlineflag 1
+comp_thingsectorlight 0
 ```
 
 ### Ultimate Doom
@@ -255,4 +260,5 @@ comp_ledgeblock 1
 comp_friendlyspawn 1
 comp_voodooscroller 0
 comp_reservedlineflag 1
+comp_thingsectorlight 0
 ```


### PR DESCRIPTION
`Alongside the fake heights transfer (242), Boom also introduced two separate line specials that individually transfer floor and ceiling light levels (213 and 261) onto a tagged sector. Normally, in Boom and CL9, any Things present in said sector will be lit according to the sector's normal light level. MBF, however, changed this behavior to decide a Thing's light level using the average of the transferred floor and ceiling light levels, instead.`

Not only is the MBF behavior incredibly unpopular among mappers, the choice of which behavior is also widely inconsistent among ports. Some ports will only use the Boom behavior of defining a Thing's light level based on the true sector, some will only use the MBF behavior and others will only read the transferred floor light level, instead. This proposition formally defines the behavior in question as part of MBF21.